### PR TITLE
application/conectivity_bridge: Add dir and file type variable init.

### DIFF
--- a/applications/connectivity_bridge/src/disk/config.c
+++ b/applications/connectivity_bridge/src/disk/config.c
@@ -344,6 +344,7 @@ static void parse_file(const char *mnt_point)
 		return;
 	}
 
+	fs_file_t_init(&file);
 	err = fs_open(&file, fname, FS_O_CREATE | FS_O_RDWR);
 	if (err) {
 		LOG_ERR("fs_open: %d", err);

--- a/applications/connectivity_bridge/src/events/fs_event.c
+++ b/applications/connectivity_bridge/src/events/fs_event.c
@@ -40,6 +40,7 @@ int fs_event_helper_file_write(
 		return -ENOMEM;
 	}
 
+	fs_file_t_init(&file);
 	err = fs_open(&file, fname, FS_O_CREATE | FS_O_RDWR);
 	if (err) {
 		return err;

--- a/applications/connectivity_bridge/src/modules/fs_handler.c
+++ b/applications/connectivity_bridge/src/modules/fs_handler.c
@@ -44,6 +44,7 @@ static int fs_init(void)
 	/* The default RAM disk may contain unwanted files. Erase these. */
 	struct fs_dir_t dir;
 
+	fs_dir_t_init(&dir);
 	err = fs_opendir(&dir, FATFS_MNTP "/");
 	if (err) {
 		LOG_ERR("fs_opendir: %d", err);


### PR DESCRIPTION
The commit adds initializations of fs_dir_t variables in preparation
for fs_opendir function change that will require fs_dir_t object, passed
to the function, to be initialized before first usage.

The commit adds initializations of fs_file_t variables in preparation
for fs_open function change that will require fs_file_t object, passed
to the function, to be initialized before first usage.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>