### PR TITLE
cmake: multi image: using BOARD and REVISION arguments for zephyr_file()

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -78,6 +78,13 @@ endfunction()
 #                    files for BOARD or the current board if BOARD argument is
 #                    not given.
 #                    CONF_FILES takes the following additional arguments:
+#                    BOARD <board>:             Find configuration files for specified board.
+#                    BOARD_REVISION <revision>: Find configuration files for specified board
+#                                               revision. Requires BOARD to be specified.
+#
+#                                               If no board is given the current BOARD and
+#                                               BOARD_REVISION will be used.
+#
 #                    DTS <list>:   List to populate with DTS overlay files
 #                    KCONF <list>: List to populate with Kconfig fragment files
 #                    BUILD <type>: Build type to include for search.
@@ -92,13 +99,9 @@ function(ncs_file)
 Please provide one of following: CONF_FILES")
   endif()
 
-  set(single_args CONF_FILES BOARD)
+  set(single_args CONF_FILES)
   cmake_parse_arguments(FILE "" "${single_args}" "" ${ARGN})
   cmake_parse_arguments(ZEPHYR_FILE "" "KCONF;DTS;BUILD" "" ${ARGN})
-
-  if(FILE_BOARD)
-    set(BOARD ${FILE_BOARD})
-  endif()
 
   if(ZEPHYR_FILE_KCONF)
     if(ZEPHYR_FILE_BUILD AND EXISTS ${FILE_CONF_FILES}/prj_${ZEPHYR_FILE_BUILD}.conf)

--- a/cmake/multi_image.cmake
+++ b/cmake/multi_image.cmake
@@ -181,6 +181,8 @@ function(add_child_image_from_source)
   if (NOT ${ACI_NAME}_CONF_FILE)
     ncs_file(CONF_FILES ${ACI_NAME_CONF_DIR}
              BOARD ${ACI_BOARD}
+             # Child image always uses the same revision as parent board.
+             BOARD_REVISION ${BOARD_REVISION}
              KCONF ${ACI_NAME}_CONF_FILE
              BUILD ${CONF_FILE_BUILD_TYPE}
     )


### PR DESCRIPTION
Now specifying BOARD as argument to zephyr_file() instead of setting it
as a local scope variable.

This remove the warning printed during multi image builds where the
board is changed when looking up Kconfig fragments and DT overlay files.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>