### PR TITLE
driver: Made entropy_cc3xx available in pre-kernel

### DIFF
--- a/drivers/entropy/entropy_cc310.c
+++ b/drivers/entropy/entropy_cc310.c
@@ -103,5 +103,5 @@ static const struct entropy_driver_api entropy_cc3xx_rng_api = {
 #endif
 
 DEVICE_DT_DEFINE(CRYPTOCELL_NODE_ID, entropy_cc3xx_rng_init,
-		 device_pm_control_nop, NULL, NULL, POST_KERNEL,
+		 device_pm_control_nop, NULL, NULL, PRE_KERNEL_2,
 		 CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &entropy_cc3xx_rng_api);

--- a/drivers/hw_cc310/Kconfig
+++ b/drivers/hw_cc310/Kconfig
@@ -28,15 +28,4 @@ menuconfig HW_CC3XX
 	help
 	  This option enables the Arm CC3xx hw devices in nRF52840, nRF53, and nRF9160 devices.
 
-if HW_CC3XX
-
-config HW_CC3XX_NAME
-	string "Entropy Device Name"
-	default "HW_CC3XX_0"
-	help
-	  Specify the device name to be used for the HW_CC3XX driver.
-
-
-endif # HW_CC3XX
-
 endif # !HW_CC3XX_FORCE_ALT

--- a/drivers/hw_cc310/hw_cc310.c
+++ b/drivers/hw_cc310/hw_cc310.c
@@ -17,17 +17,11 @@
 
 #if CONFIG_HW_CC3XX
 
-static int hw_cc3xx_init(const struct device *dev)
+static int hw_cc3xx_init_internal(const struct device *dev)
 {
 	int res;
 
 	__ASSERT_NO_MSG(dev != NULL);
-
-	/* Set the RTOS abort APIs */
-	nrf_cc3xx_platform_abort_init();
-
-	/* Set the RTOS mutex APIs */
-	nrf_cc3xx_platform_mutex_init();
 
 	/* Initialize the cc3xx HW with or without RNG support */
 #if CONFIG_ENTROPY_CC3XX
@@ -35,11 +29,32 @@ static int hw_cc3xx_init(const struct device *dev)
 #else
 	res = nrf_cc3xx_platform_init_no_rng();
 #endif
+
 	return res;
 }
 
-SYS_DEVICE_DEFINE(CONFIG_HW_CC3XX_NAME, hw_cc3xx_init, device_pm_control_nop,
-		  POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+static int hw_cc3xx_init(const struct device *dev)
+{
+	int res;
+
+	/* Set the RTOS abort APIs */
+	nrf_cc3xx_platform_abort_init();
+
+	/* Set the RTOS mutex APIs */
+	nrf_cc3xx_platform_mutex_init();
+
+	/* Enable the hardware */
+	res = hw_cc3xx_init_internal(dev);
+	return res;
+}
+
+/* Driver initalization done when mutex is not usable (pre kernel) */
+SYS_INIT(hw_cc3xx_init_internal, PRE_KERNEL_2,
+ 	 CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+
+/* Driver initialization when mutex is usable (post kernel) */
+SYS_INIT(hw_cc3xx_init, POST_KERNEL,
+ 	 CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 
 #endif /* CONFIG_HW_CC3XX */
 


### PR DESCRIPTION
-Add duplicate drivers for hw_cc3xx, one using no mutex and one using
 mutex. This allows using entropy from kernel mode
-Used PRE_KERNEL_2 for hw_cc3xx and entropy_cc3xx
-Removed unneccesary label HW_CC3XX_NAME

ref: NCSDK-8780

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>