### PR TITLE
tests: app_event_manager: Allow to return after assert post action

### DIFF
--- a/tests/subsys/app_event_manager/prj.conf
+++ b/tests/subsys/app_event_manager/prj.conf
@@ -6,6 +6,10 @@
 
 CONFIG_ZTEST=y
 
+# Assert test mode must be enabled, because assert post action handler must return (i.e. not abort)
+# after an assertion failure.
+CONFIG_ASSERT_TEST=y
+
 # Configuration required by Application Event Manager
 CONFIG_APP_EVENT_MANAGER=y
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048


### PR DESCRIPTION
Enable CONFIG_ASSERT_TEST Kconfig option to allow returning after an assertion failure.

Jira: NCSDK-17440