### PR TITLE
applications: nrf_desktop: Fix compiler warnings

### DIFF
--- a/applications/nrf_desktop/src/hw_interface/board.c
+++ b/applications/nrf_desktop/src/hw_interface/board.c
@@ -22,7 +22,7 @@ LOG_MODULE_REGISTER(MODULE, CONFIG_DESKTOP_BOARD_LOG_LEVEL);
 
 
 static int port_setup(const struct device *port,
-		      const struct pin_state pin_state[],
+		      const struct pin_state *pin_state,
 		      size_t cnt)
 {
 	int err = 0;
@@ -50,7 +50,7 @@ static int port_setup(const struct device *port,
 	return err;
 }
 
-static int ports_setup(const struct port_state port_state[], size_t cnt)
+static int ports_setup(const struct port_state *port_state, size_t cnt)
 {
 	int err = 0;
 

--- a/applications/nrf_desktop/src/modules/hid_state.c
+++ b/applications/nrf_desktop/src/modules/hid_state.c
@@ -519,7 +519,11 @@ static bool key_value_set(struct items *items, uint16_t usage_id, int16_t value)
 	/* Report equal to zero brings no change. This should never happen. */
 	__ASSERT_NO_MSG(value != 0);
 
-	p_item = bsearch(&usage_id,
+	struct item i = {
+		.usage_id = usage_id,
+	};
+
+	p_item = bsearch(&i,
 			 (uint8_t *)items->item,
 			 ARRAY_SIZE(items->item),
 			 sizeof(items->item[0]),


### PR DESCRIPTION
Change switches to specifying arguments as pointers to prevent -Wstringop-overread compiler warning.

Jira: NCSDK-17440