### PR TITLE
bluetooth: rpc: remove unnecessary source

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-1.4.1.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-1.4.1.rst
@@ -92,7 +92,7 @@ Zephyr changes incorporated into |NCS|
 
 This section contains changes in Zephyr that were cherry-picked into |NCS| for this release.
 
-* Added support for the :ref:`zephyr:actinius_icarus` board.
+* Added support for the :zephyr:board:`actinius_icarus` board.
 
 Bluetooth Host
 ~~~~~~~~~~~~~~

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -14,7 +14,7 @@ PyYAML                          # |  X  |         |        |         |         |
 pykwalify                       # |     |         |        |         |         |      |   X    |
 pytest                          # |     |         |        |         |         |      |   X    |
 recommonmark                    # |     |         |   X    |    X    |         |      |        |
-sphinx~=7.4                     # |  X  |    X    |   X    |    X    |    X    |  X   |   X    |
+sphinx~=8.1                     # |  X  |    X    |   X    |    X    |    X    |  X   |   X    |
 sphinx-autobuild                # |  X  |    X    |   X    |    X    |    X    |  X   |   X    |
 sphinx-copybutton               # |  X  |         |        |         |         |      |   X    |
 sphinx-ncs-theme<1.1            # |  X  |         |        |         |         |      |        |

--- a/doc/zephyr/conf.py
+++ b/doc/zephyr/conf.py
@@ -27,7 +27,7 @@ ZEPHYR_BASE = utils.get_projdir("zephyr")
 
 # Import all Zephyr configuration, override as needed later
 os.environ["ZEPHYR_BASE"] = str(ZEPHYR_BASE)
-os.environ["ZEPHYR_BUILD"] = str(utils.get_builddir() / "zephyr")
+os.environ["OUTPUT_DIR"] = str(utils.get_builddir() / "html" / "zephyr")
 
 conf = eval_config_file(str(ZEPHYR_BASE / "doc" / "conf.py"), tags)
 locals().update(conf)


### PR DESCRIPTION
The bluetooth shell has been refactored (see
bf897cf941a514e7ea7a5f837d2287e360281f24), so the sourced file no longer exists. Note that it was actually a bad use of sourcing, as the upstream options are already part of the Kconfig tree (unless I missed something).