### PR TITLE
suit: Fix warnings in unit tests

### DIFF
--- a/tests/subsys/suit/unit/app_specific/suit_plat_retrieve_manifest_app/src/main.c
+++ b/tests/subsys/suit/unit/app_specific/suit_plat_retrieve_manifest_app/src/main.c
@@ -13,8 +13,8 @@ ZTEST_SUITE(suit_platform_retrieve_manifest_tests, NULL, NULL, NULL, NULL, NULL)
 ZTEST(suit_platform_retrieve_manifest_tests, test_retrieve_manifest_app_specific)
 {
 	struct zcbor_string dummy_component_id = {0};
-	uint8_t *envelope = NULL;
-	size_t envelope_len = 0;
+	const uint8_t **envelope = NULL;
+	size_t *envelope_len = NULL;
 
 	/* Simply return SUIT_ERR_UNSUPPORTED_COMPONENT_ID unconditionally */
 	zassert_equal(suit_plat_retrieve_manifest_domain_specific(&dummy_component_id,

--- a/tests/subsys/suit/unit/suit_plat_memptr_size_update/src/main.c
+++ b/tests/subsys/suit/unit/suit_plat_memptr_size_update/src/main.c
@@ -18,8 +18,6 @@
 #define TEST_COMPONENT_SIZE_SMALLER ((size_t)128)
 #define TEST_COMPONENT_SIZE_BIGGER  ((size_t)512)
 
-static size_t smaller_component_size = 128, bigger_component_size = 512;
-
 static void test_before(void *data)
 {
 	/* Reset mocks */


### PR DESCRIPTION
Fix warnings in SUIT unit tests.

Ref: NCSDK-31359