### PR TITLE
samples: nrf5340: empty_app_core: Use new DT node to check lfxo enabled

### DIFF
--- a/samples/nrf5340/empty_app_core/src/main.c
+++ b/samples/nrf5340/empty_app_core/src/main.c
@@ -10,6 +10,8 @@
 #include <nrf.h>
 #include <nrfx.h>
 
+#define LFXO_NODE DT_NODELABEL(lfxo)
+
 /** @brief Power OFF entire RAM and suspend CPU forever.
  *
  * Function operates only on `register` variables, so GCC will not use
@@ -59,7 +61,11 @@ static int network_gpio_allow(void)
 	 * and P0.01 (XL2), as they need to stay configured with the value
 	 * Peripheral.
 	 */
-	uint32_t start_pin = (IS_ENABLED(CONFIG_SOC_ENABLE_LFXO) ? 2 : 0);
+#if DT_NODE_HAS_PROP(LFXO_NODE, load_capacitors) || defined(CONFIG_SOC_ENABLE_LFXO)
+	uint32_t start_pin = 2;
+#else
+	uint32_t start_pin = 0;
+#endif
 
 	/* Allow the network core to use all GPIOs. */
 	for (uint32_t i = start_pin; i < P0_PIN_NUM; i++) {


### PR DESCRIPTION
CONFIG_SOC_ENABLE_LFXO has been deprecated in zephyr in favour of a DT_NODE, so update the handling of this in empty_app_core sample.