### PR TITLE
esb: Fix DPPIC instance selection for nRF54 SoCs

### DIFF
--- a/samples/esb/esb_prx/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/esb/esb_prx/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Enable DPPI driver
+CONFIG_NRFX_DPPI10=y

--- a/samples/esb/esb_ptx/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/samples/esb/esb_ptx/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Enable DPPI driver
+CONFIG_NRFX_DPPI10=y

--- a/subsys/esb/esb_dppi.c
+++ b/subsys/esb/esb_dppi.c
@@ -227,7 +227,7 @@ int esb_ppi_init(void)
 
 #else
 
-	nrfx_dppi_t dppi = NRFX_DPPI_INSTANCE(0);
+	nrfx_dppi_t dppi = NRFX_DPPI_INSTANCE(ESB_DPPIC_INSTANCE_NO);
 
 	err = nrfx_dppi_channel_alloc(&dppi, &radio_address_timer_stop);
 	if (err != NRFX_SUCCESS) {
@@ -319,7 +319,7 @@ void esb_ppi_deinit(void)
 
 #else
 
-	nrfx_dppi_t dppi = NRFX_DPPI_INSTANCE(0);
+	nrfx_dppi_t dppi = NRFX_DPPI_INSTANCE(ESB_DPPIC_INSTANCE_NO);
 
 	err = nrfx_dppi_channel_free(&dppi, radio_address_timer_stop);
 	if (err != NRFX_SUCCESS) {

--- a/subsys/esb/esb_peripherals.h
+++ b/subsys/esb/esb_peripherals.h
@@ -26,8 +26,8 @@ extern "C" {
 	/** The ESB Radio interrupt number. */
 	#define ESB_RADIO_IRQ_NUMBER RADIO_0_IRQn
 
-	/** DPPIC instance used by ESB. */
-	#define ESB_DPPIC NRF_DPPIC020
+	/** DPPIC instance number used by ESB. */
+	#define ESB_DPPIC_INSTANCE_NO 020
 
 	/** ESB EGU instance configuration. */
 	#define ESB_EGU NRF_EGU020
@@ -47,8 +47,8 @@ extern "C" {
 	/** The ESB Radio interrupt number. */
 	#define ESB_RADIO_IRQ_NUMBER RADIO_0_IRQn
 
-	/** DPPIC instance used by ESB. */
-	#define ESB_DPPIC NRF_DPPIC10
+	/** DPPIC instance number used by ESB. */
+	#define ESB_DPPIC_INSTANCE_NO 10
 
 	/** ESB EGU instance configuration. */
 	#define ESB_EGU NRF_EGU10
@@ -66,8 +66,8 @@ extern "C" {
 	/** The ESB Radio interrupt number. */
 	#define ESB_RADIO_IRQ_NUMBER RADIO_IRQn
 
-	/** DPPIC instance used by ESB. */
-	#define ESB_DPPIC NRF_DPPIC
+	/** DPPIC instance number used by ESB. */
+	#define ESB_DPPIC_INSTANCE_NO 0
 
 	/** ESB EGU instance configuration. */
 	#define ESB_EGU NRF_EGU0
@@ -79,6 +79,13 @@ extern "C" {
 	#define ESB_RADIO_INT_END_MASK NRF_RADIO_INT_END_MASK
 
 #endif
+
+/** ESB DPPIC instance number. */
+#if ESB_DPPIC_INSTANCE_NO
+#define ESB_DPPIC NRFX_CONCAT_2(NRF_DPPIC, ESB_DPPIC_INSTANCE_NO)
+#else
+#define ESB_DPPIC NRF_DPPIC
+#endif /* ESB_DPPIC_INSTANCE_NO */
 
 /** ESB timer instance number. */
 #if defined(CONFIG_ESB_SYS_TIMER_INSTANCE_LEADING_ZERO)


### PR DESCRIPTION
Fixing DPPIC instances for nRF54L15