### PR TITLE
secure_storage: make the build fail in case of unsupported configuration

### DIFF
--- a/subsys/CMakeLists.txt
+++ b/subsys/CMakeLists.txt
@@ -13,6 +13,7 @@ add_subdirectory_ifdef(CONFIG_SECURE_BOOT_STORAGE bootloader/bl_storage)
 
 add_subdirectory_ifdef(CONFIG_NRF_SECURITY nrf_security)
 add_subdirectory_ifdef(CONFIG_TRUSTED_STORAGE trusted_storage)
+add_subdirectory_ifdef(CONFIG_SECURE_STORAGE secure_storage)
 
 add_subdirectory(net)
 add_subdirectory_ifdef(CONFIG_ESB		esb)

--- a/subsys/secure_storage/CMakeLists.txt
+++ b/subsys/secure_storage/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+if(CONFIG_SECURE_STORAGE_ITS_STORE_IMPLEMENTATION_ZMS AND CONFIG_PARTITION_MANAGER_ENABLED)
+  message(FATAL_ERROR "
+    CONFIG_SECURE_STORAGE_ITS_STORE_IMPLEMENTATION_ZMS is
+    not supported when partition manager is enabled.
+    ")
+endif()


### PR DESCRIPTION
The ZMS implementation of the ITS store module is not supported when partition manager is used because the DT chosen
`secure_storage_its_partition` cannot be used.
This would require using a different, partition manager-specific configuration.
As partition manager will be replaced this combination is just not supported.