### PR TITLE
doc: nrf: wifi: remove incorrect doxygen group

### DIFF
--- a/doc/nrf/libraries/networking/wifi_credentials.rst
+++ b/doc/nrf/libraries/networking/wifi_credentials.rst
@@ -66,5 +66,3 @@ API documentation
 
 | Header file: :file:`include/zephyr/net/wifi_credentials.h`
 | Source files: :file:`subsys/net/lib/wifi_credentials`
-
-.. doxygengroup:: wifi_credentials


### PR DESCRIPTION
We cannot render/link Doxygen groups that belong to another project like Zephyr, see https://github.com/nrfconnect/sdk-nrf/pull/19341 for progress on that.