### PR TITLE
quarantine_zephyr: Add secure_storage scenarios to quarantine

### DIFF
--- a/scripts/quarantine_zephyr.yaml
+++ b/scripts/quarantine_zephyr.yaml
@@ -251,6 +251,14 @@
     - qemu_cortex_m3/ti_lm3s6965
   comment: "https://nordicsemi.atlassian.net/browse/NCSDK-31671"
 
+- scenarios:
+    - secure_storage.psa.its.secure_storage.*
+    - sample.psa.persistent_key.secure_storage.entropy_driver
+    - secure_storage.psa.crypto.secure_storage
+  platforms:
+    - native_sim/native
+  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-31681"
+
 # ---------------------------------   Won't fix section -----------------------------------
 
 - scenarios:


### PR DESCRIPTION
Test configurations with secure_storage should be
move to quarantine due to issues on native_sim
platform.