### PR TITLE
quarantine_zephyr: Add quarantine for kernel.common.toolchain

### DIFF
--- a/scripts/quarantine_zephyr.yaml
+++ b/scripts/quarantine_zephyr.yaml
@@ -527,3 +527,9 @@
   platforms:
     - native_sim/native
   comment: "requires pulling in hal_atmel but is actually not very useful"
+
+- scenarios:
+    - kernel.common.toolchain
+  platforms:
+    - native_sim/native
+  comment: "clang is not available in our toolchain"


### PR DESCRIPTION
Clang is not available in our toolchain, therefore test kernel.common.toolchain will fail.