### PR TITLE
tests: lib: location: Fix unity cmock generation

### DIFF
--- a/tests/lib/location/CMakeLists.txt
+++ b/tests/lib/location/CMakeLists.txt
@@ -41,6 +41,7 @@ cmock_handle(${ZEPHYR_BASE}/include/zephyr/net/net_if.h
   FUNC_EXCLUDE ".*net_if_add_tx_timestamp"
   FUNC_EXCLUDE ".*net_if_ipv4_get_netmask"
   FUNC_EXCLUDE ".*net_if_ipv4_set_netmask"
+  FUNC_EXCLUDE ".*net_if_offload_set"
   WORD_EXCLUDE ".*deprecated.*"
   WORD_EXCLUDE ".*net_if_send_data.*"
   WORD_EXCLUDE ".*net_if_try_send_data.*"


### PR DESCRIPTION
net_if_offload_set() function was added upstream causing mock generation failures, add it to the exclude list.