### PR TITLE
nrf_security: fix up enabling of CONFIG_MBEDTLS_USE_PSA_CRYPTO

### DIFF
--- a/subsys/nrf_security/Kconfig.psa
+++ b/subsys/nrf_security/Kconfig.psa
@@ -40,10 +40,7 @@ config MBEDTLS_PSA_CRYPTO_STORAGE_C
 	  Corresponds to MBEDTLS_PSA_CRYPTO_STORAGE_C setting in mbed TLS config file.
 
 config MBEDTLS_USE_PSA_CRYPTO
-	bool "PSA APIs for X.509 and TLS library"
-	default y if !MBEDTLS_LEGACY_CRYPTO_C
-	help
-	  Corresponds to MBEDTLS_USE_PSA_CRYPTO setting in mbed TLS config file.
+	default n if MBEDTLS_LEGACY_CRYPTO_C
 
 config MBEDTLS_PSA_KEY_SLOT_COUNT
 	int "Number of PSA key slots available"


### PR DESCRIPTION
Now that we inherit Zephyr's Kconfig.tf-psa-crypto, CONFIG_MBEDTLS_USE_PSA_CRYPTO gets automatically enabled whenever CONFIG_MBEDTLS_PSA_CRYPTO_CLIENT.

However it's always y whenever we use nrf_security, so in that case make CONFIG_MBEDTLS_USE_PSA_CRYPTO default to n when we would previously not make it default to y.

This restores the previous enabling behavior that we've had.