### PR TITLE
manifest: sdk-hostap: Use sdk-hostap instead of upstream hostap

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -92,7 +92,6 @@ manifest:
           - hal_st # required for ST sensors (unrelated to STM32 MCUs)
           - hal_tdk # required for Invensense sensors such as ICM42670
           - hal_wurthelektronik
-          - hostap
           - liblc3
           - libmetal
           - libsbc
@@ -275,6 +274,10 @@ manifest:
       revision: d5fad6bd094899101a4e5fd53af7298160ced6ab
       groups:
         - benchmark
+    - name: hostap
+      repo-path: sdk-hostap
+      path: modules/lib/hostap
+      revision: 8fd18deb93f639919650fd7a35546a958c3f25c6
 
   # West-related configuration for the nrf repository.
   self:


### PR DESCRIPTION
Avoid using changes done in upstream for MbedTLS upgrade. Revert to using upstream hostap once MbedTLS upgrade related changes are merged in sdk-mbedtls repo.