### PR TITLE
nrf_security: avoid redefinition of MBEDTLS_PSA_STATIC_KEY_SLOTS

### DIFF
--- a/subsys/nrf_security/Kconfig.psa
+++ b/subsys/nrf_security/Kconfig.psa
@@ -52,12 +52,6 @@ config MBEDTLS_PSA_KEY_SLOT_COUNT
 	  transparent keys that we can have open concurrently.
 	  The default value comes from MBedTLS.
 
-config MBEDTLS_PSA_STATIC_KEY_SLOTS
-	bool "Static key slots for PSA"
-	help
-	  When this option is enabled the PSA core doesn't use the heap to store keys.
-	  It uses a static buffer to hold the key material.
-
 config PSA_CRYPTO_SYS_INIT
 	bool "Invoke psa_crypto_init during system initialization"
 	default y

--- a/subsys/nrf_security/configs/legacy_crypto_config.h.template
+++ b/subsys/nrf_security/configs/legacy_crypto_config.h.template
@@ -3322,7 +3322,7 @@
  * Requires: MBEDTLS_PSA_CRYPTO_C
  *
  */
-#cmakedefine MBEDTLS_PSA_STATIC_KEY_SLOTS
+//#cmakedefine MBEDTLS_PSA_STATIC_KEY_SLOTS
 
 /**
  * \def MBEDTLS_RIPEMD160_C


### PR DESCRIPTION
Do not define it in the legacy config file otherwise in certain scenarios we end up in a double definition of this symbol because it's already defined in psa_crypto_config which contains the PSA_NEEDs.

At the same time remove the definition of
CONFIG_MBEDTLS_PSA_STATIC_KEY_SLOTS from nrf_security because we now inherit it from Zephyr's Kconfig.tf-psa-crypto.