### PR TITLE
tests: tfm: tfm_psa_test: disable problematic Kconfig options

### DIFF
--- a/tests/tfm/tfm_psa_test/prj.conf
+++ b/tests/tfm/tfm_psa_test/prj.conf
@@ -6,6 +6,11 @@
 
 CONFIG_TFM_USE_NS_APP=y
 
+# Disable features resulting in undefined references
+# when wrongfully building the Zephyr NS app.
+CONFIG_PSA_CRYPTO_SYS_INIT=n
+CONFIG_TFM_ALLOW_NON_SECURE_FAULT_HANDLING=n
+
 # Needed for CRYPTO and INITIAL_ATTESTATION
 CONFIG_MAIN_STACK_SIZE=4096
 CONFIG_TFM_CRYPTO_ENGINE_BUF_SIZE=16536


### PR DESCRIPTION
Commit `06dd00c340948455c30608c273e2a9bbd15f5543` in Zephyr put part of the TF-M CMake integration behind `NOT CONFIG_TFM_USE_NS_APP`.

It makes sense because when `CONFIG_TFM_USE_NS_APP` is enabled we shouldn't build the NS app because TF-M is providing it.

However in that scenario we still wrongfully build and then discard the Zephyr NS app, and now this results in undefined references to functions.

Fix those by turning off the features which result in code needing TF-M functions that are not made available anymore.