### PR TITLE
img_mgmt: Use custom logic for merged slot

### DIFF
--- a/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
@@ -11,6 +11,7 @@ config MCUMGR_GRP_IMG_NRF
 	depends on MCUMGR_GRP_IMG
 	default y if PARTITION_MANAGER_ENABLED
 	default y if MCUMGR_GRP_IMG_TOO_LARGE_BOOTLOADER_INFO
+	default y if NCS_MCUBOOT_BOOTLOADER_SIGN_MERGED_BINARY
 	help
 	  Enables use of an extended version of the image management implementation that adds
 	  Nordic-specific functionalities.


### PR DESCRIPTION
Use custom logic when merged slot approach is in use.

Ref: NCSDK-NONE