### PR TITLE
doc: replace broken intersphinx refs to old Zephyr release notes

### DIFF
--- a/doc/nrf/releases_and_maturity/releases/release-notes-1.4.0.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-1.4.0.rst
@@ -513,7 +513,9 @@ For a complete list of |NCS| specific commits, run:
    git log --oneline manifest-rev ^7a3b253ced
 
 The current |NCS| release is based on Zephyr v2.4.0.
-See the :ref:`Zephyr v2.4.0 release notes <zephyr:zephyr_2.4>` for the list of changes.
+See the `Zephyr v2.4.0 release notes`_ for the list of changes.
+
+.. _Zephyr v2.4.0 release notes: https://docs.zephyrproject.org/2.4.0/releases/release-notes-2.4.html
 
 Additions specific to |NCS|
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/nrf/releases_and_maturity/releases/release-notes-1.4.1.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-1.4.1.rst
@@ -85,7 +85,9 @@ For a complete list of |NCS| specific commits, run:
    git log --oneline manifest-rev ^7a3b253ced
 
 The current |NCS| release is based on Zephyr v2.4.0.
-See the :ref:`Zephyr v2.4.0 release notes <zephyr:zephyr_2.4>` for the list of changes.
+See the `Zephyr v2.4.0 release notes`_ for the list of changes.
+
+.. _Zephyr v2.4.0 release notes: https://docs.zephyrproject.org/2.4.0/releases/release-notes-2.4.html
 
 Zephyr changes incorporated into |NCS|
 --------------------------------------

--- a/doc/nrf/releases_and_maturity/releases/release-notes-1.6.0.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-1.6.0.rst
@@ -487,7 +487,9 @@ For a complete list of |NCS| specific commits, run:
    git log --oneline manifest-rev ^v2.6.0-rc1
 
 The current |NCS| release is based on Zephyr v2.6.0-rc1.
-See the :ref:`zephyr:zephyr_2.6` Release Notes for an overview of the most important changes inherited from upstream Zephyr.
+See the `Zephyr v2.6.0 release notes`_ for an overview of the most important changes inherited from upstream Zephyr.
+
+.. _Zephyr v2.6.0 release notes: https://docs.zephyrproject.org/2.6.0/releases/release-notes-2.6.html
 
 Zephyr Workqueue API Migration
 ------------------------------


### PR DESCRIPTION
## Summary
- Upstream Zephyr commit `5f87c741572` ("doc: conf.py: exclude EOL release notes and migration guides from build") added EOL release notes to `exclude_patterns`, so labels like `zephyr_2.4` / `zephyr_2.6` are no longer in the intersphinx inventory (the `:orphan:` source files still exist but aren't built).
- This breaks the Zephyr Doxygen / Sphinx build for NCS release notes 1.4.0, 1.4.1 and 1.6.0, which use `:ref:\`...zephyr:zephyr_2.4\`` / `zephyr_2.6`.
- Replace the broken intersphinx refs with direct links to Zephyr's archived versioned docs (`docs.zephyrproject.org/2.4.0/...`, `docs.zephyrproject.org/2.6.0/...`), which still serve those release notes.

## Test plan
- [ ] Documentation Build job passes on the upmerge PR (#27726) once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)